### PR TITLE
feature(stab-fee): add poolpairs with stab fee api query

### DIFF
--- a/packages/walletkit-core/src/website/website.ts
+++ b/packages/walletkit-core/src/website/website.ts
@@ -108,6 +108,13 @@ export interface DeFiChainStatus {
   }>;
 }
 
+export interface PoolpairWithStabInfo {
+  tokenADisplaySymbol: string;
+  tokenBDisplaySymbol: string;
+  dexStabilizationFee: string;
+  highFeeScanUrl: string;
+}
+
 export type Platform = "ios" | "android" | "windows" | "macos" | "web";
 
 export type App = "MOBILE_LW" | "DESKTOP_LW" | "SCAN";

--- a/packages/walletkit-core/src/website/website.ts
+++ b/packages/walletkit-core/src/website/website.ts
@@ -109,10 +109,10 @@ export interface DeFiChainStatus {
 }
 
 export interface PoolpairWithStabInfo {
+  pairDisplaySymbol: string;
   tokenADisplaySymbol: string;
   tokenBDisplaySymbol: string;
   dexStabilizationFee: string;
-  highFeeScanUrl: string;
 }
 
 export type Platform = "ios" | "android" | "windows" | "macos" | "web";

--- a/packages/walletkit-ui/src/store/website.ts
+++ b/packages/walletkit-ui/src/store/website.ts
@@ -3,6 +3,7 @@ import {
   AnnouncementData,
   DeFiChainStatus,
   FeatureFlag,
+  PoolpairWithStabInfo,
 } from "@waveshq/walletkit-core";
 
 export const statusWebsiteSlice = createApi({
@@ -53,18 +54,33 @@ export const announcementWebsiteSlice = createApi({
         },
       }),
     }),
+    getPairsWithStabilizationFee: builder.query<PoolpairWithStabInfo[], any>({
+      query: (reqParams) => ({
+        url: "/wallet/pairs-with-stab-info",
+        params: reqParams,
+        method: "GET",
+        headers: {
+          "Access-Control-Allow-Origin": "*",
+          mode: "no-cors",
+        },
+      }),
+    }),
   }),
 });
 
 const { useGetBlockchainStatusQuery, useGetOceanStatusQuery } =
   statusWebsiteSlice;
-const { useGetAnnouncementsQuery, useGetFeatureFlagsQuery, usePrefetch } =
-  announcementWebsiteSlice;
-
+const {
+  useGetAnnouncementsQuery,
+  useGetFeatureFlagsQuery,
+  usePrefetch,
+  useGetPairsWithStabilizationFeeQuery,
+} = announcementWebsiteSlice;
 export {
   useGetAnnouncementsQuery,
   useGetBlockchainStatusQuery,
   useGetFeatureFlagsQuery,
   useGetOceanStatusQuery,
+  useGetPairsWithStabilizationFeeQuery,
   usePrefetch,
 };


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
Adds reducer query for `https://wallet.defichain.com/api/v0/wallet/pairs-with-stab-info` to the `walletkit-ui`.
Part of our long-term solution to remove list of hardcoded pairs with stabilization fee.
Merging this PR wont affect any existing product.

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:
