### PR TITLE
feature(walletkit-core): added method to get address type from address and network as input

### DIFF
--- a/packages/walletkit-core/src/api/address.ts
+++ b/packages/walletkit-core/src/api/address.ts
@@ -1,4 +1,4 @@
-import { fromScript } from "@defichain/jellyfish-address";
+import { fromScript, fromAddress } from "@defichain/jellyfish-address";
 import { NetworkName } from "@defichain/jellyfish-network";
 import { OP_PUSHDATA, Script } from "@defichain/jellyfish-transaction";
 import { ethers } from "ethers";
@@ -76,6 +76,28 @@ export function getDecodedAddress(
       script,
       network,
     };
+  } catch (e) {
+    return undefined;
+  }
+}
+
+export function getAddressType ( 
+  address: string,
+  network: NetworkName
+): AddressType | undefined {
+  try {
+    // check if is dfc address first
+    const decodedAddress = fromAddress(address, network);
+    if (decodedAddress !== undefined) {
+      return decodedAddress.type;
+    }
+
+    // check if the address is evm
+    const isEVMAddress = ethers.utils.isAddress(address);
+    if(isEVMAddress) {
+      return AddressType.ETH
+    }    
+    return undefined
   } catch (e) {
     return undefined;
   }

--- a/packages/walletkit-core/src/api/address.ts
+++ b/packages/walletkit-core/src/api/address.ts
@@ -1,4 +1,4 @@
-import { fromScript, fromAddress } from "@defichain/jellyfish-address";
+import { fromAddress, fromScript } from "@defichain/jellyfish-address";
 import { NetworkName } from "@defichain/jellyfish-network";
 import { OP_PUSHDATA, Script } from "@defichain/jellyfish-transaction";
 import { ethers } from "ethers";
@@ -81,7 +81,7 @@ export function getDecodedAddress(
   }
 }
 
-export function getAddressType ( 
+export function getAddressType(
   address: string,
   network: NetworkName
 ): AddressType | undefined {
@@ -94,10 +94,10 @@ export function getAddressType (
 
     // check if the address is evm
     const isEVMAddress = ethers.utils.isAddress(address);
-    if(isEVMAddress) {
-      return AddressType.ETH
-    }    
-    return undefined
+    if (isEVMAddress) {
+      return AddressType.ETH;
+    }
+    return undefined;
   } catch (e) {
     return undefined;
   }

--- a/packages/walletkit-core/src/api/address.unit.ts
+++ b/packages/walletkit-core/src/api/address.unit.ts
@@ -1,6 +1,11 @@
 import { OP_CODES, Script } from "@defichain/jellyfish-transaction";
 
-import { AddressType, EthDecodedAddress, getDecodedAddress } from "./address";
+import {
+  AddressType,
+  EthDecodedAddress,
+  getAddressType,
+  getDecodedAddress,
+} from "./address";
 
 /* detailed `fromScript()` test cases are done in @defichain/jellyfish-address */
 describe("Address Decoder", () => {
@@ -20,7 +25,6 @@ describe("Address Decoder", () => {
       script,
       network: "testnet",
     };
-
     expect(getDecodedAddress(script, "testnet")).toStrictEqual(expected);
   });
 
@@ -74,5 +78,30 @@ describe("Address Decoder", () => {
     };
 
     expect(getDecodedAddress(script, "testnet")).toBeUndefined();
+  });
+});
+
+describe("Get Address Type", () => {
+  const addresses = [
+    {
+      address: "tf1qzvvn8rp2q93w5rf9afpjjm2w2wtuu2fnvl6j3p",
+      type: AddressType.P2WPKH,
+    },
+    {
+      address: "tf1qncd7qa2cafwv3cpw68vqczg3qj904k2f4lard4wrj50rzkwmagvsemeex5",
+      type: AddressType.P2WSH,
+    },
+    { address: "77nPza1LqwQzS9jMCnxVV3xKYWnLLZePwo", type: AddressType.P2PKH },
+    { address: "tkwD8teFiwr9fGwwX2KfgrgYRbwEiWmMJw", type: AddressType.P2SH },
+    {
+      address: "0xe36f18af5bFfDcB442E84970408F68570aB88F52",
+      type: AddressType.ETH,
+    },
+  ];
+
+  addresses.forEach(({ address, type }) => {
+    it(`should be able to get valid ${type} address type`, () => {
+      expect(getAddressType(address, "testnet")).toStrictEqual(type);
+    });
   });
 });

--- a/packages/walletkit-core/src/api/address.unit.ts
+++ b/packages/walletkit-core/src/api/address.unit.ts
@@ -104,4 +104,10 @@ describe("Get Address Type", () => {
       expect(getAddressType(address, "testnet")).toStrictEqual(type);
     });
   });
+
+  it(`should be able to get valid undefined with wrong address`, () => {
+    expect(
+      getAddressType("bcrt1q6cxskutl6jf0jjeqxc3ymfuqakhw4r247tht58", "testnet")
+    ).toStrictEqual(undefined);
+  });
 });


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
To support EVM chain, getAddressType is function which will return  a address type using address string and network.
#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:
